### PR TITLE
Rename Console API to Admin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ When an AI agent loads a skill, it gains the ability to help you build, deploy, 
 
 | Skill | Description |
 |-------|-------------|
-| `quicknode-skill` | Quicknode infrastructure - RPC endpoints (80+ chains), Streams, Webhooks, IPFS, Add-ons, Yellowstone gRPC, Hypercore, x402, Key-Value Store, SDK, Console API |
+| `quicknode-skill` | Quicknode infrastructure - RPC endpoints (80+ chains), Streams, Webhooks, IPFS, Add-ons, Yellowstone gRPC, Hypercore, x402, Key-Value Store, SDK, Admin API |
 
 ## Installation
 

--- a/skills/quicknode-skill/SKILL.md
+++ b/skills/quicknode-skill/SKILL.md
@@ -33,7 +33,7 @@ description: Quicknode blockchain infrastructure including RPC endpoints (80+ ch
 | **DAS API** | Solana Digital Asset Standard (add-on) | NFT/token queries, compressed NFTs, asset search |
 | **Yellowstone gRPC** | Solana Geyser streaming (add-on) | Real-time account, transaction, slot data |
 | **Hypercore** | Hyperliquid gRPC/JSON-RPC/WS (beta) | Trades, orders, book updates, blocks, TWAP, events, writer actions |
-| **Console API** | REST API for account management | Endpoint CRUD, usage monitoring, billing |
+| **Admin API** | REST API for account management | Endpoint CRUD, usage monitoring, billing |
 | **Key-Value Store** | Serverless key-value and list storage (beta) | Persistent state for Streams, dynamic address lists |
 | **x402** | Pay-per-request RPC via USDC micropayments | Keyless RPC access, AI agents, pay-as-you-go |
 
@@ -384,7 +384,7 @@ const nfts = await core.client.qn_fetchNFTs({
 
 See [references/sdk-reference.md](references/sdk-reference.md) for complete SDK documentation.
 
-## Console API
+## Admin API
 
 REST API for programmatic management of Quicknode endpoints, usage, rate limits, security, billing, and teams. Enables infrastructure-as-code workflows.
 
@@ -414,7 +414,7 @@ const res = await fetch('https://api.quicknode.com/v0/endpoints', {
 const endpoints = await res.json();
 ```
 
-See [references/console-api-reference.md](references/console-api-reference.md) for full Console API documentation including endpoint CRUD, usage monitoring, rate limit configuration, security options, billing, and teams.
+See [references/admin-api-reference.md](references/admin-api-reference.md) for full Admin API documentation including endpoint CRUD, usage monitoring, rate limit configuration, security options, billing, and teams.
 
 ## Key-Value Store (Beta)
 
@@ -560,7 +560,7 @@ const ethBalance = await chains.ethereum.client.getBalance({ address: '0x...' })
 - **Webhooks**: https://www.quicknode.com/docs/webhooks
 - **IPFS**: https://www.quicknode.com/docs/ipfs
 - **SDK**: https://www.quicknode.com/docs/quicknode-sdk
-- **Console API**: https://www.quicknode.com/docs/console-api
+- **Admin API**: https://www.quicknode.com/docs/admin-api
 - **DAS API (Solana)**: https://www.quicknode.com/docs/solana/solana-das-api
 - **Yellowstone gRPC**: https://www.quicknode.com/docs/solana/yellowstone-grpc/overview
 - **Hyperliquid**: https://www.quicknode.com/docs/hyperliquid

--- a/skills/quicknode-skill/references/admin-api-reference.md
+++ b/skills/quicknode-skill/references/admin-api-reference.md
@@ -1,4 +1,4 @@
-# Quicknode Console API Reference
+# Quicknode Admin API Reference
 
 REST API for programmatic management of Quicknode endpoints, usage monitoring, rate limits, security, billing, and teams.
 
@@ -29,7 +29,7 @@ All requests require the `x-api-key` header. Generate an API key from the Quickn
 const QN_API_KEY = process.env.QUICKNODE_API_KEY!;
 const BASE_URL = 'https://api.quicknode.com/v0';
 
-async function consoleApi<T>(
+async function adminApi<T>(
   path: string,
   options: RequestInit = {}
 ): Promise<T> {
@@ -43,20 +43,20 @@ async function consoleApi<T>(
   });
   if (!res.ok) {
     const body = await res.text();
-    throw new Error(`Console API ${res.status}: ${body}`);
+    throw new Error(`Admin API ${res.status}: ${body}`);
   }
   return res.json();
 }
 ```
 
-All examples below reuse this `consoleApi` helper.
+All examples below reuse this `adminApi` helper.
 
 ## Chains
 
 List all supported blockchain networks.
 
 ```typescript
-const chains = await consoleApi<{ data: Array<{
+const chains = await adminApi<{ data: Array<{
   id: string;
   name: string;
   network: string;
@@ -71,7 +71,7 @@ chains.data.forEach(c => console.log(`${c.name} (${c.network})`));
 ### List Endpoints
 
 ```typescript
-const endpoints = await consoleApi<{ data: Array<{
+const endpoints = await adminApi<{ data: Array<{
   id: string;
   name: string;
   chain: string;
@@ -96,13 +96,13 @@ endpoints.data.forEach(ep =>
 
 ```typescript
 // Paginate with tag filter
-const filtered = await consoleApi('/endpoints?tag=production&page=1&per_page=10');
+const filtered = await adminApi('/endpoints?tag=production&page=1&per_page=10');
 ```
 
 ### Create Endpoint
 
 ```typescript
-const newEndpoint = await consoleApi('/endpoints', {
+const newEndpoint = await adminApi('/endpoints', {
   method: 'POST',
   body: JSON.stringify({
     name: 'my-eth-mainnet',
@@ -125,14 +125,14 @@ console.log('Created:', newEndpoint.http_url);
 ### Get Endpoint
 
 ```typescript
-const endpoint = await consoleApi(`/endpoints/${endpointId}`);
+const endpoint = await adminApi(`/endpoints/${endpointId}`);
 console.log(endpoint.http_url, endpoint.status);
 ```
 
 ### Update Endpoint
 
 ```typescript
-const updated = await consoleApi(`/endpoints/${endpointId}`, {
+const updated = await adminApi(`/endpoints/${endpointId}`, {
   method: 'PATCH',
   body: JSON.stringify({ name: 'renamed-endpoint' }),
 });
@@ -142,13 +142,13 @@ const updated = await consoleApi(`/endpoints/${endpointId}`, {
 
 ```typescript
 // Pause
-await consoleApi(`/endpoints/${endpointId}/status`, {
+await adminApi(`/endpoints/${endpointId}/status`, {
   method: 'PATCH',
   body: JSON.stringify({ status: 'paused' }),
 });
 
 // Unpause
-await consoleApi(`/endpoints/${endpointId}/status`, {
+await adminApi(`/endpoints/${endpointId}/status`, {
   method: 'PATCH',
   body: JSON.stringify({ status: 'active' }),
 });
@@ -157,17 +157,17 @@ await consoleApi(`/endpoints/${endpointId}/status`, {
 ### Archive (Delete) Endpoint
 
 ```typescript
-await consoleApi(`/endpoints/${endpointId}`, { method: 'DELETE' });
+await adminApi(`/endpoints/${endpointId}`, { method: 'DELETE' });
 ```
 
 ### Tags
 
 ```typescript
 // List tags on an endpoint
-const tags = await consoleApi(`/endpoints/${endpointId}/tags`);
+const tags = await adminApi(`/endpoints/${endpointId}/tags`);
 
 // Add tags
-await consoleApi(`/endpoints/${endpointId}/tags`, {
+await adminApi(`/endpoints/${endpointId}/tags`, {
   method: 'POST',
   body: JSON.stringify({ tags: ['production', 'critical'] }),
 });
@@ -178,7 +178,7 @@ await consoleApi(`/endpoints/${endpointId}/tags`, {
 Retrieve performance metrics for an endpoint.
 
 ```typescript
-const metrics = await consoleApi<{ data: {
+const metrics = await adminApi<{ data: {
   total_requests: number;
   success_rate: number;
   avg_latency_ms: number;
@@ -202,7 +202,7 @@ console.log('Avg latency:', metrics.data.avg_latency_ms, 'ms');
 ### Get Method Rate Limits
 
 ```typescript
-const methodLimits = await consoleApi(
+const methodLimits = await adminApi(
   `/endpoints/${endpointId}/method-rate-limits`
 );
 console.log(methodLimits);
@@ -213,7 +213,7 @@ console.log(methodLimits);
 Restrict specific RPC methods on an endpoint.
 
 ```typescript
-await consoleApi(`/endpoints/${endpointId}/method-rate-limits`, {
+await adminApi(`/endpoints/${endpointId}/method-rate-limits`, {
   method: 'POST',
   body: JSON.stringify({
     method_rate_limits: [
@@ -235,7 +235,7 @@ await consoleApi(`/endpoints/${endpointId}/method-rate-limits`, {
 ### Set Global Rate Limits
 
 ```typescript
-await consoleApi(`/endpoints/${endpointId}/rate-limits`, {
+await adminApi(`/endpoints/${endpointId}/rate-limits`, {
   method: 'PUT',
   body: JSON.stringify({
     rps: 100,   // requests per second
@@ -258,7 +258,7 @@ await consoleApi(`/endpoints/${endpointId}/rate-limits`, {
 Retrieve security configuration for an endpoint.
 
 ```typescript
-const security = await consoleApi(
+const security = await adminApi(
   `/endpoints/${endpointId}/security_options`
 );
 console.log(security);
@@ -278,7 +278,7 @@ console.log(security);
 ### Total RPC Usage
 
 ```typescript
-const usage = await consoleApi<{ data: {
+const usage = await adminApi<{ data: {
   total_requests: number;
   total_credits: number;
 } }>('/usage/rpc?start_time=2025-01-01T00:00:00Z&end_time=2025-01-31T23:59:59Z');
@@ -297,7 +297,7 @@ console.log('Credits used:', usage.data.total_credits);
 ### Usage by Endpoint
 
 ```typescript
-const byEndpoint = await consoleApi(
+const byEndpoint = await adminApi(
   '/usage/rpc/by-endpoint?start_time=2025-01-01T00:00:00Z&end_time=2025-01-31T23:59:59Z'
 );
 ```
@@ -305,7 +305,7 @@ const byEndpoint = await consoleApi(
 ### Usage by Method
 
 ```typescript
-const byMethod = await consoleApi(
+const byMethod = await adminApi(
   '/usage/rpc/by-method?start_time=2025-01-01T00:00:00Z&end_time=2025-01-31T23:59:59Z'
 );
 ```
@@ -313,7 +313,7 @@ const byMethod = await consoleApi(
 ### Usage by Chain
 
 ```typescript
-const byChain = await consoleApi(
+const byChain = await adminApi(
   '/usage/rpc/by-chain?start_time=2025-01-01T00:00:00Z&end_time=2025-01-31T23:59:59Z'
 );
 ```
@@ -323,7 +323,7 @@ const byChain = await consoleApi(
 Retrieve invoice history.
 
 ```typescript
-const invoices = await consoleApi<{ data: Array<{
+const invoices = await adminApi<{ data: Array<{
   id: string;
   amount: number;
   currency: string;
@@ -342,7 +342,7 @@ invoices.data.forEach(inv =>
 List team members and roles.
 
 ```typescript
-const teams = await consoleApi<{ data: Array<{
+const teams = await adminApi<{ data: Array<{
   id: string;
   name: string;
   members: Array<{
@@ -363,7 +363,7 @@ teams.data.forEach(team => {
 Query request logs for an endpoint. Available on Enterprise plans.
 
 ```typescript
-const logs = await consoleApi<{ data: Array<{
+const logs = await adminApi<{ data: Array<{
   timestamp: string;
   method: string;
   status_code: number;
@@ -408,8 +408,8 @@ Returns metrics in Prometheus exposition format, suitable for scraping.
 
 ## Documentation
 
-- **Console API Docs**: https://www.quicknode.com/docs/console-api
-- **Console API Docs (llms.txt)**: https://www.quicknode.com/docs/console-api/llms.txt
+- **Admin API Docs**: https://www.quicknode.com/docs/admin-api
+- **Admin API Docs (llms.txt)**: https://www.quicknode.com/docs/admin-api/llms.txt
 - **Quicknode Dashboard**: https://dashboard.quicknode.com/
 - **API Key Management**: https://dashboard.quicknode.com/settings/api-keys
-- **Guides**: https://www.quicknode.com/guides/tags/console-api
+- **Guides**: https://www.quicknode.com/guides/tags/admin-api


### PR DESCRIPTION
## Summary
- Rename `console-api-reference.md` → `admin-api-reference.md`
- Update all "Console API" references to "Admin API" across SKILL.md, README.md, and the reference file
- Update code identifiers (`consoleApi` → `adminApi`) and URLs (`console-api` → `admin-api`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only rename; primary risk is broken links or confusion if any external references still expect the old `Console API` naming/URLs.
> 
> **Overview**
> **Renames the Quicknode “Console API” docs to “Admin API”** across repo documentation.
> 
> Updates README and `skills/quicknode-skill/SKILL.md` product listings/section titles, switches reference links to `references/admin-api-reference.md`, and updates doc URLs from `console-api` to `admin-api`. The API reference content is likewise rebranded, including code snippet identifiers (`consoleApi` → `adminApi`) and error messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91262c909aeac674451d109fd7ab3c8ee5c01215. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->