### PR TITLE
Fix SKILL.md frontmatter description quoting

### DIFF
--- a/skills/quicknode-skill/SKILL.md
+++ b/skills/quicknode-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quicknode-skill
-description: Quicknode blockchain infrastructure: endpoint access for 80+ chains over RPC/WebSocket/gRPC/REST, Streams, Webhooks, SQL Explorer, IPFS, Solana DAS API, Yellowstone and Hypercore gRPC, Key-Value Store, Admin API, x402 and MPP pay-per-request RPC, and Agent Subscriptions. Use for any Quicknode product, qn_ methods, blockchain data access on Ethereum, Solana, Hyperliquid and other supported chains, or wallet-paid agent access (x402, MPP, agent subscription).
+description: "Quicknode blockchain infrastructure: endpoint access for 80+ chains over RPC/WebSocket/gRPC/REST, Streams, Webhooks, SQL Explorer, IPFS, Solana DAS API, Yellowstone and Hypercore gRPC, Key-Value Store, Admin API, x402 and MPP pay-per-request RPC, and Agent Subscriptions. Use for any Quicknode product, qn_ methods, blockchain data access on Ethereum, Solana, Hyperliquid and other supported chains, or wallet-paid agent access (x402, MPP, agent subscription)."
 ---
 
 # Quicknode Blockchain Infrastructure


### PR DESCRIPTION
## Summary
Quote the  value in  so the current  CLI can parse the YAML frontmatter.

## Verification
- Reproduced failure with 
│
●   codex  Agent detected — installing non-interactively
[?25l│
◇  Source: 
[?25h[?25l│
│
■  Failed to clone repository
│
│  Failed to clone ...: fatal: repository '...' does not exist
│
│
│  Tip: use the --yes (-y) and --global (-g) flags to install without prompts.
│
└  Installation failed

■  Canceled
[?25h
- Verified the local repo is discovered after quoting the description

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adjusts YAML frontmatter formatting; impact limited to tooling that parses `SKILL.md` metadata.
> 
> **Overview**
> Fixes `skills/quicknode-skill/SKILL.md` YAML frontmatter by quoting the `description` value so YAML parsers/CLI tooling can reliably read the skill metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66668da094400a115368c9af078dda2f511deb0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->